### PR TITLE
Force request cache

### DIFF
--- a/src/M6Web/Bundle/WSClientBundle/Cache/Guzzle/ForcedCachePlugin.php
+++ b/src/M6Web/Bundle/WSClientBundle/Cache/Guzzle/ForcedCachePlugin.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace M6Web\Bundle\WSClientBundle\Cache\Guzzle;
+
+use Guzzle\Plugin\Cache\CachePlugin as GuzzleCachePlugin;
+use Guzzle\Http\Message\RequestInterface;
+use Guzzle\Http\Message\Response;
+
+/**
+ * Forced cache plugin
+ */
+class ForcedCachePlugin extends GuzzleCachePlugin
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function canResponseSatisfyRequest(RequestInterface $request, Response $response)
+    {
+        return true;
+    }
+}

--- a/src/M6Web/Bundle/WSClientBundle/DependencyInjection/M6WebWSClientExtension.php
+++ b/src/M6Web/Bundle/WSClientBundle/DependencyInjection/M6WebWSClientExtension.php
@@ -58,15 +58,22 @@ class M6WebWSClientExtension extends Extension
         $definition->addMethodCall('setStopWatch', array(new Reference('debug.stopwatch', ContainerInterface::NULL_ON_INVALID_REFERENCE)));
 
         if (array_key_exists('cache', $config)) {
+
+            $cacheClass = '\Guzzle\Plugin\Cache\CachePlugin';
+
+            if ($config['cache']['force_request_ttl'])
+            {
+                $definition->addMethodCall('setRequestTtl', array($config['cache']['ttl']));
+                $cacheClass = '\M6Web\Bundle\WSClientBundle\Cache\Guzzle\ForcedCachePlugin';
+            }
+
             $definition->addMethodCall('setCache', array(
                 $config['cache']['ttl'],
                 array_key_exists('service', $config['cache']) ? new Reference($config['cache']['service']) : null,
-                array_key_exists('adapter', $config['cache']) ? $config['cache']['adapter'] : ''
+                array_key_exists('adapter', $config['cache']) ? $config['cache']['adapter'] : '',
+                $cacheClass
             ));
 
-            if ($config['cache']['force_request_ttl']) {
-                $definition->addMethodCall('setRequestTtl', array($config['cache']['ttl']));
-            }
 
             if (array_key_exists('resetter', $config['cache'])) {
                 if (array_key_exists('service', $config['cache']['resetter'])) {


### PR DESCRIPTION
On a beaucoup de hit dans redis parce que le cache des requêtes n'était pas vraiment forcé.
A tagger en 2.0.1 si mergé, merci.
