### PR TITLE
Add dependancies on Symfony/Stopwatch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
         "psr-0": { "": "src/" }
     },
     "minimum-stability" : "dev",
+    "require": {
+        "symfony/stopwatch" : "@stable"
+    },
     "require-dev": {
         "atoum/atoum": "master-dev",
         "atoum/atoum-bundle": "master-dev",


### PR DESCRIPTION
This bundle require Symfony/Stopwatch library [here](https://github.com/M6Web/WsClientBundle/blob/master/src/M6Web/Bundle/WSClientBundle/Adapter/Client/ClientAdapterInterface.php#L8)
