### PR TITLE
Rename method getHeadears() to getHeaders()

### DIFF
--- a/src/M6Web/Bundle/WSClientBundle/Adapter/Response/GuzzleResponseAdapter.php
+++ b/src/M6Web/Bundle/WSClientBundle/Adapter/Response/GuzzleResponseAdapter.php
@@ -82,7 +82,7 @@ class GuzzleResponseAdapter implements ResponseAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getHeadears()
+    public function getHeaders()
     {
         return $this->response->getHeaders();
     }

--- a/src/M6Web/Bundle/WSClientBundle/Adapter/Response/ResponseAdapterInterface.php
+++ b/src/M6Web/Bundle/WSClientBundle/Adapter/Response/ResponseAdapterInterface.php
@@ -37,6 +37,8 @@ interface ResponseAdapterInterface
 
     /**
      * retourne un header de la réponse
+     * @param string $header Header name
+     *
      * @return string
      */
     public function getHeader($header);
@@ -45,6 +47,6 @@ interface ResponseAdapterInterface
      * retourne les headers de la réponse
      * @return array
      */
-    public function getHeadears();
+    public function getHeaders();
 
 }


### PR DESCRIPTION
#14
