### PR TITLE
Add __call auto proxy in GuzzleResponseAdapter

### DIFF
--- a/src/M6Web/Bundle/WSClientBundle/Adapter/Response/GuzzleResponseAdapter.php
+++ b/src/M6Web/Bundle/WSClientBundle/Adapter/Response/GuzzleResponseAdapter.php
@@ -107,7 +107,7 @@ class GuzzleResponseAdapter implements ResponseAdapterInterface
     public function __call($name, $arguments)
     {
         if (!method_exists($this->response, $name)) {
-            throw new BadMethodCallException("Method ".$name." doesn't exist in Guzzle Response");
+            throw new \BadMethodCallException("Method ".$name." doesn't exist in ".get_class($this->response));
         }
 
         return call_user_func_array(array($this->response, $name), $arguments);

--- a/src/M6Web/Bundle/WSClientBundle/Adapter/Response/GuzzleResponseAdapter.php
+++ b/src/M6Web/Bundle/WSClientBundle/Adapter/Response/GuzzleResponseAdapter.php
@@ -95,4 +95,22 @@ class GuzzleResponseAdapter implements ResponseAdapterInterface
         return $header;
     }
 
+    /**
+     *  Magic method to the Response adapter
+     *
+     * @param string $name      method name
+     * @param array  $arguments method arguments
+     *
+     * @throws Exception
+     * @return mixed
+     */
+    public function __call($name, $arguments)
+    {
+        if (!method_exists($this->response, $name)) {
+            throw new BadMethodCallException("Method ".$name." doesn't exist in Guzzle Response");
+        }
+
+        return call_user_func_array(array($this->response, $name), $arguments);
+    }
+
 }

--- a/src/M6Web/Bundle/WSClientBundle/Adapter/Response/GuzzleResponseAdapter.php
+++ b/src/M6Web/Bundle/WSClientBundle/Adapter/Response/GuzzleResponseAdapter.php
@@ -39,14 +39,6 @@ class GuzzleResponseAdapter implements ResponseAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getStatusCode()
-    {
-        return $this->response->getStatusCode();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function isContentType($type)
     {
         return (strtolower($this->getContentType()) == strtolower($type));
@@ -58,22 +50,6 @@ class GuzzleResponseAdapter implements ResponseAdapterInterface
     public function getContentType()
     {
         return $this->getHeader('Content-Type');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getHeader($header)
-    {
-        return $this->response->getHeader($header);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getHeaders()
-    {
-        return $this->response->getHeaders();
     }
 
     /**

--- a/src/M6Web/Bundle/WSClientBundle/Adapter/Response/ResponseAdapterInterface.php
+++ b/src/M6Web/Bundle/WSClientBundle/Adapter/Response/ResponseAdapterInterface.php
@@ -15,13 +15,6 @@ interface ResponseAdapterInterface
     public function getBody();
 
     /**
-     * Return the response status
-     *
-     * @return int
-     */
-    public function getStatusCode();
-
-    /**
      * Return content type
      *
      * @param string $type Content type to check against
@@ -36,22 +29,6 @@ interface ResponseAdapterInterface
      * @return string
      */
     public function getContentType();
-
-    /**
-     * Return a specific header response
-     *
-     * @param string $header Header name
-     *
-     * @return string
-     */
-    public function getHeader($header);
-
-    /**
-     * Return headers response
-     *
-     * @return array
-     */
-    public function getHeaders();
 
     /**
      * return a scalar value of \Guzzle\Http\Message\Header type


### PR DESCRIPTION
Add __call magic method to auto proxy GuzzleResponse methods in the Adapter.
Should I also remove getStatusCode, getHeader and getHeaders from GuzzleAdapter and the interface since they are useless with the __call ?