### PR TITLE
Fix deprecated setFactoryService/Method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "guzzlehttp/guzzle" : "@stable",
         "m6web/coke": "~1.2",
         "m6web/symfony2-coding-standard": "~2.0",
-        "symfony/symfony"   : "~2.3"
+        "symfony/symfony"   : "~2.7"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/M6Web/Bundle/WSClientBundle/DependencyInjection/M6WebWSClientExtension.php
+++ b/src/M6Web/Bundle/WSClientBundle/DependencyInjection/M6WebWSClientExtension.php
@@ -50,8 +50,7 @@ class M6WebWSClientExtension extends Extension
     {
         $serviceId  = 'm6_ws_client' . ($alias != 'default' ? '_' . $alias : '');
         $definition = new Definition('M6Web\Bundle\WSClientBundle\Adapter\WSClientAdapterInterface');
-        $definition->setFactoryService('m6_ws_client.factory');
-        $definition->setFactoryMethod('getClient');
+        $definition->setFactory([new Reference('m6_ws_client.factory'), 'getClient']);
         $definition->setScope(ContainerInterface::SCOPE_CONTAINER);
 
         $definition->addArgument(new Reference('service_container'));


### PR DESCRIPTION
Compatibility with Symfony 2.7

setFactoryService and setFactoryMethod are now deprecated.